### PR TITLE
duplicate workflow definition

### DIFF
--- a/.github/workflows/build-release-and-publish-gem.yml
+++ b/.github/workflows/build-release-and-publish-gem.yml
@@ -11,7 +11,36 @@ permissions:
 name: Build Release and Publish Gem
 
 jobs:
-  build-release-and-publish-gem:
-    uses: sh24/github-actions/.github/workflows/build-release-and-publish-gem.yml@main
-    with:
-      gem-name: ${{ github.event.repository.name }}
+  release-please:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: ruby
+          package-name: frontapp
+          version-file: lib/frontapp/version.rb
+
+      - uses: actions/checkout@v3
+        if: steps.release.outputs.release_created
+
+      - uses: ruby/setup-ruby@v1
+        if: steps.release.outputs.release_created
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+        env:
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{secrets.PRIVATE_PACKAGE_REGISTRY_PERSONAL_ACCESS_TOKEN}}
+
+      - name: Publish to GitHub
+        if: steps.release.outputs.release_created
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:github: Bearer ${GITHUB_TOKEN}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push --KEY github --host https://rubygems.pkg.github.com/${GITHUB_REPOSITORY_OWNER} *.gem
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
can't use shared workflow because the repo is public and a fork cannot be changed to private